### PR TITLE
Documentation - Updated README, minor renaming and version pinning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,5 @@
 .env
 
 # Transform files
-/transforms/dbt_packages
-/transforms/logs
+/transform/dbt_packages
+/transform/logs

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 /venv
 /.meltano
 .env
+
+# Transform files
+/transforms/dbt_packages
+/transforms/logs

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This is a Meltano project for `tap-theme-parks` to sync data to `target-jsonl` or `target-postgres`.
 
+For more information about some of the plugins in this project, check out these GitHub repos and their READMEs:
+- [tap-theme-parks](https://github.com/DanielPDWalker/tap-theme-parks)
+- [dbt-tap-theme-parks](https://github.com/DanielPDWalker/dbt-tap-theme-parks) (Only applicable if using `target-postgres``, find out more below)
+
 ## Setup
 
 ### Prerequisites
@@ -25,10 +29,21 @@ Now you will see some `.json` files in the `output/` directory containing theme 
 
 ### Using other targets
 
-If you want to persist you data to a postgres (or any other database/destination), you will need to provide the credentials for this project to connect to it. **See step 2 below.**
+If you want to persist you data a different target, you will need to have an instance of that target and provide the credentials for this project to connect to it. **See step 2 below.**
 
 Its as easy a browsing the [MeltanoHub](https://hub.meltano.com/), finding the loader you want to use and then:
 
 1. `meltano add loader <chosen-loader>`
 1. [Provide your settings for the loader](https://docs.meltano.com/guide/configuration)
 1. `meltano run tap-theme-parks <chosen-loader>`
+
+### Using target-postgres
+
+If you `target-postgres`, again by having a postgres database and the credentials to connect to it, you can then use the dbt project included in this project. 
+
+The [dbt-tap-theme-parks]() project takes data from the raw tables created by [tap-theme-parks]() and build easy to use and query dimension and fact tables. It also includes a snapshot to keep track of the most recent live data that you sync.
+
+There is a Meltano job already in this project to run with postgres and dbt:
+
+`meltano run tap-theme-parks-to-target-postgres`
+ 

--- a/meltano.yml
+++ b/meltano.yml
@@ -9,7 +9,7 @@ plugins:
   extractors:
   - name: tap-theme-parks
     variant: danielpdwalker
-    pip_url: git+https://github.com/DanielPDWalker/tap-theme-parks.git@v0.0.1
+    pip_url: git+https://github.com/DanielPDWalker/tap-theme-parks.git@v0.0.3
   loaders:
   - name: target-postgres
     variant: transferwise
@@ -28,7 +28,7 @@ plugins:
 jobs:
 - name: tap-theme-parks-to-target-postgres
   tasks:
-  - tap-theme-parks target-postgres
+  - tap-theme-parks target-postgres dbt:deps dbt:snapshot dbt:run
 schedules:
 - name: theme-park-sync
   interval: '@daily'

--- a/plugins/extractors/tap-theme-parks--danielpdwalker.lock
+++ b/plugins/extractors/tap-theme-parks--danielpdwalker.lock
@@ -6,7 +6,7 @@
   "label": "Theme Parks",
   "docs": "https://github.com/DanielPDWalker/tap-theme-parks",
   "repo": "https://github.com/DanielPDWalker/tap-theme-parks",
-  "pip_url": "git+https://github.com/DanielPDWalker/tap-theme-parks.git@v0.0.1",
+  "pip_url": "git+https://github.com/DanielPDWalker/tap-theme-parks.git@v0.0.3",
   "description": "Tap for theme park data.",
   "capabilities": [
     "discover",

--- a/transform/dbt_packages/tap_theme_parks
+++ b/transform/dbt_packages/tap_theme_parks
@@ -1,1 +1,0 @@
-/home/dw/Documents/dan-repos/dbt-tap-theme-parks

--- a/transform/dbt_project.yml
+++ b/transform/dbt_project.yml
@@ -1,4 +1,4 @@
-name: theme_park_project
+name: theme_parks_project
 version: "1.0"
 require-dbt-version: [">=1.0.0", "<2.0.0"]
 profile: meltano
@@ -23,4 +23,4 @@ clean-targets:
   - dbt_packages
   - logs
 models:
-  theme_park_project: null
+  theme_parks_project: null

--- a/transform/dbt_project.yml
+++ b/transform/dbt_project.yml
@@ -1,4 +1,4 @@
-name: my_meltano_project
+name: theme_park_project
 version: "1.0"
 require-dbt-version: [">=1.0.0", "<2.0.0"]
 profile: meltano
@@ -23,4 +23,4 @@ clean-targets:
   - dbt_packages
   - logs
 models:
-  my_meltano_project: null
+  theme_park_project: null

--- a/transform/packages.yml
+++ b/transform/packages.yml
@@ -1,2 +1,3 @@
 packages:
-  - local: /home/dw/Documents/dan-repos/dbt-tap-theme-parks
+  - git: https://github.com/DanielPDWalker/dbt-tap-theme-parks
+    revision: v0.1.0


### PR DESCRIPTION
closes #1 

- Updated `.gitignore` and removed the `dbt_packages` dir committed in error.
- Pinned the version of `dbt-tap-theme-parks` and `tap-theme-parks` plugins
- Renamed `dbt_project.yml` name to `theme_parks_project`
- Updated README with better description and more info about how to use the plugins in this project.