### PR TITLE
Bump tap-theme-park version

### DIFF
--- a/meltano.yml
+++ b/meltano.yml
@@ -9,7 +9,7 @@ plugins:
   extractors:
   - name: tap-theme-parks
     variant: danielpdwalker
-    pip_url: git+https://github.com/DanielPDWalker/tap-theme-parks.git@v0.0.3
+    pip_url: git+https://github.com/DanielPDWalker/tap-theme-parks.git@v0.0.4
   loaders:
   - name: target-postgres
     variant: transferwise

--- a/plugins/extractors/tap-theme-parks--danielpdwalker.lock
+++ b/plugins/extractors/tap-theme-parks--danielpdwalker.lock
@@ -6,7 +6,7 @@
   "label": "Theme Parks",
   "docs": "https://github.com/DanielPDWalker/tap-theme-parks",
   "repo": "https://github.com/DanielPDWalker/tap-theme-parks",
-  "pip_url": "git+https://github.com/DanielPDWalker/tap-theme-parks.git@v0.0.3",
+  "pip_url": "git+https://github.com/DanielPDWalker/tap-theme-parks.git@v0.0.4",
   "description": "Tap for theme park data.",
   "capabilities": [
     "discover",


### PR DESCRIPTION
`tap-theme-parks` has a new release bumping some dependency versions.